### PR TITLE
Update image_compressor_widget.dart

### DIFF
--- a/lib/widgets/image_compressor_widget.dart
+++ b/lib/widgets/image_compressor_widget.dart
@@ -36,7 +36,7 @@ class _ImageCompressorWidgetState extends State<ImageCompressorWidget> {
     }
 
     final dir = await path_provider.getTemporaryDirectory();
-    final targetPath = '${dir.absolute.path}/temp.jpg';
+    final targetPath = '${dir.absolute.path}/${DateTime.now().millisecondsSinceEpoch}.jpg';
 
     // converting original image to compress it
     final result = await FlutterImageCompress.compressAndGetFile(


### PR DESCRIPTION
The issue with the original code was that it was using the same filename (temp.jpg) for every image that was compressed. This could cause problems because the new image would overwrite the old one, but Flutter's image provider might still show the old image due to caching. To fix this issue, a unique filename is generated for each image by using the current timestamp. The line added to the code is:  final targetPath = '${dir.absolute.path}/${DateTime.now().millisecondsSinceEpoch}.jpg';